### PR TITLE
use open(), not file() in Python3

### DIFF
--- a/tmda/TMDA/Queue/OriginalQueue.py
+++ b/tmda/TMDA/Queue/OriginalQueue.py
@@ -116,7 +116,7 @@ class OriginalQueue(Queue):
 
     def fetch_message(self, mailid, fullParse=False):
         fpath = os.path.join(Defaults.PENDING_DIR, mailid + '.msg')
-        msg = Util.msg_from_file(file(fpath, 'rb'), fullParse=fullParse, isBytes=True)
+        msg = Util.msg_from_file(open(fpath, 'rb'), fullParse=fullParse, isBytes=True)
         return msg
 
 


### PR DESCRIPTION
I got an error when trying to use tmda-pending.  This fixed it.