### PR TITLE
Repair of mishandled filter sources `from*`.

### DIFF
--- a/tmda/TMDA/rfilter.py
+++ b/tmda/TMDA/rfilter.py
@@ -781,8 +781,8 @@ def main():
                                                          envelope_sender)
     if confirm_append_address:
         senders.add(confirm_append_address)
-    senders.union(a[1].lower() for a in getaddresses(msgin.get_all('from', [])))
-    senders.union(a[1].lower() for a in getaddresses(msgin.get_all('reply-to', [])))
+    for a in getaddresses(msgin.get_all('from'    , [])): senders.add(a[1].lower())
+    for a in getaddresses(msgin.get_all('reply-to', [])): senders.add(a[1].lower())
 
     sender_list = list(senders)
     # Process confirmation messages first.


### PR DESCRIPTION
My TMDA is stable nowadays, Paul.  What I’ve been sending you lately are the patches that stabilized it.

There’s still a few on the stack, I’ll let you know when it’s empty.

The one I’m sending here, I no longer have the test cases for.  I can’t explain why that `for` generator was failing under 3.9.  And I couldn’t back then either (I’m not a Python guy).  But this patch repaired it for me.