### PR TITLE
Robust logging

### DIFF
--- a/tmda/TMDA/MessageLogger.py
+++ b/tmda/TMDA/MessageLogger.py
@@ -62,10 +62,13 @@ class MessageLogger:
         if XPri:
             self.__writeline('XPri', XPri)
         envsender = self.vardict.get('envsender', None)
-        if (envsender
-            and parseaddr(self.msg.get('from'))[1] != envsender):
-            self.__writeline('Sndr', envsender)
         From = self.msg.get('from')
+        try:
+            to_log_sender = envsender and (not From or parseaddr(From)[1] != envsender)
+        except TypeError: # From `parseaddr`, e.g. when `From` contains Unicode 92 (PRIVATE USE TWO).
+            to_log_sender = True
+        if to_log_sender:
+            self.__writeline('Sndr', envsender)
         if From:
             self.__writeline('From', From)
         ReplyTo = self.msg.get('reply-to')

--- a/tmda/TMDA/MessageLogger.py
+++ b/tmda/TMDA/MessageLogger.py
@@ -70,7 +70,8 @@ class MessageLogger:
         if to_log_sender:
             self.__writeline('Sndr', envsender)
         if From:
-            self.__writeline('From', From)
+            self.__writeline('From', From) # May yield the likes of “From: <email.header.Header object at
+              # 0x7fbdecadecb0>”, at least when the `parseaddr` further above has thrown a `TypeError`.
         ReplyTo = self.msg.get('reply-to')
         if ReplyTo:
             self.__writeline('Rept', ReplyTo)


### PR DESCRIPTION
This is a straightforward recovery from a parse error during message logging.  It omits nothing from the log.  The worst it does is redundantly log the envelope sender and `From` header when the two are identical.

With this, you have the latest of my patches.  The stack’s now empty.

Thanks for merging.